### PR TITLE
Remove confidence percentage from GUI

### DIFF
--- a/app.py
+++ b/app.py
@@ -432,7 +432,7 @@ class App:
 
     def _on_transcribe_done(self, text: str, confidence: float) -> None:
         self._set_text(text if text.strip() else "(transcripción vacía)")
-        self.status_var.set(f"Hecho. Confianza aprox.: {confidence * 100:.1f}%")
+        self.status_var.set("Transcripción completada.")
         self.btn_select.configure(state=tk.NORMAL)
         self.btn_transcribe.configure(state=tk.NORMAL)
         self.btn_copy.configure(state=tk.NORMAL)


### PR DESCRIPTION
## Summary

- Remove the confidence percentage display from the transcription status message
- Status now shows "Transcripción completada." instead of "Hecho. Confianza aprox.: X%"

## Changes

- Modified `_on_transcribe_done()` in `app.py` to display a simpler completion message